### PR TITLE
derive mode from special mode

### DIFF
--- a/wiktionary-bro.el
+++ b/wiktionary-bro.el
@@ -41,8 +41,8 @@
   "Keymap for `wiktionary-bro-mode'.")
 
 (define-derived-mode wiktionary-bro-mode
-  text-mode "Wiktionary"
-  "Major mode for browsing Wiktionary entries")
+  special-mode "Wiktionary"
+  "Major mode for browsing Wiktionary entries.")
 
 (defun wiktionary-bro--at-the-beginning-of-word-p (word-point)
   "Predicate to check whether `WORD-POINT' points to the beginning of the word."


### PR DESCRIPTION
text-mode is for writing text, i think you want to derive from special-mode, which is for viewing info: "A special major mode is intended to view specially formatted data rather than files.  These modes usually use read-only buffers."

rendered links and folding etc still work.

this gives you the special-mode-map by default:

key             binding
---             -------

TAB             outline-cycle
SPC             scroll-up-command
-               negative-argument
0 .. 9          digit-argument
<               beginning-of-buffer
>               end-of-buffer
?               describe-mode
g               revert-buffer
h               describe-mode
q               quit-window
DEL             scroll-down-command
S-SPC           scroll-down-command
<remap>         Prefix Command