### PR TITLE
enable `wiktionary-bro' to be called from lisp with arg

### DIFF
--- a/wiktionary-bro.el
+++ b/wiktionary-bro.el
@@ -9,18 +9,16 @@
 ;; Version: 0.0.1
 ;; Keywords: convenience multimedia
 ;; Homepage: https://github.com/agzam/wiktionary-bro.el
-;; Package-Requires: ((emacs "28.1") (request "0.3.0") (org "9"))
+;; Package-Requires: ((emacs "28.1") (request "0.3.0"))
 ;;
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 ;;
 ;; This file is not part of GNU Emacs.
 ;;
-;;; Description
-;;
-;; Lookup Wiktionary entries a bit more conveniently
-;;
 ;;; Commentary:
 ;;
+;; Lookup Wiktionary entries a bit more conveniently
+
 ;;; Code:
 
 (require 'request)
@@ -30,7 +28,7 @@
 (require 'org-indent)
 
 (defgroup wiktionary-bro nil
-  "Lookup Wiktionary entries"
+  "Lookup Wiktionary entries."
   :prefix "wiktionary-bro-"
   :group 'applications)
 
@@ -42,10 +40,10 @@
 
 (define-derived-mode wiktionary-bro-mode
   text-mode "Wiktionary"
-  "Major mode for browsing Wiktionary entries")
+  "Major mode for browsing Wiktionary entries.")
 
 (defun wiktionary-bro--at-the-beginning-of-word-p (word-point)
-  "Predicate to check whether `WORD-POINT' points to the beginning of the word."
+  "Predicate to check whether WORD-POINT points to the beginning of the word."
   (save-excursion
     ;; If we are at the beginning of a word
     ;; this will take us to the beginning of the previous word.
@@ -61,7 +59,7 @@
 
 (defun wiktionary-bro--get-original-word (beginning end)
   "Get a word to look for from the user.
-`BEGINNING' and `END' correspond to the selected text (if selected).
+BEGINNING and END correspond to the selected text (if selected).
 If presented, the selected text will be used.
 Otherwise, user must provide additional information."
   (if (use-region-p)
@@ -146,8 +144,8 @@ Otherwise, user must provide additional information."
       (rename-buffer title :uniq))))
 
 (defun wiktionary-bro (&optional beginning end)
-  "Look up a Wiktionary entry
-`BEGINNING' and `END' correspond to the selected text with a word
+  "Look up a Wiktionary entry.
+BEGINNING and END correspond to the selected text with a word
 to look up. If there is no selection provided, additional input
 will be required."
   (interactive
@@ -172,7 +170,7 @@ will be required."
               .parse.text.*))))))))
 
 (defun wiktionary-bro-at-point (word-point)
-  "Look up a Wiktionary entry for word at point."
+  "Look up a Wiktionary entry for WORD-POINT."
   (interactive (list (point)))
   (save-mark-and-excursion
     (unless (wiktionary-bro--at-the-beginning-of-word-p word-point)
@@ -185,7 +183,7 @@ will be required."
 (defun wiktionary-bro-dwim ()
   "Look up a Wiktionary entry.
 Dispatches proper fn depending of region selection or
-thing-at-point, or prompts for a word."
+`thing-at-point', or prompts for a word."
   (interactive)
   (let (beg end)
     (if (use-region-p)
@@ -198,5 +196,4 @@ thing-at-point, or prompts for a word."
         (wiktionary-bro)))))
 
 (provide 'wiktionary-bro)
-
 ;;; wiktionary-bro.el ends here

--- a/wiktionary-bro.el
+++ b/wiktionary-bro.el
@@ -143,8 +143,9 @@ Otherwise, user must provide additional information."
       (read-only-mode)
       (rename-buffer title :uniq))))
 
-(defun wiktionary-bro (&optional beginning end)
+(defun wiktionary-bro (&optional term beginning end)
   "Look up a Wiktionary entry.
+TERM is the word to search for.
 BEGINNING and END correspond to the selected text with a word
 to look up. If there is no selection provided, additional input
 will be required."
@@ -153,7 +154,7 @@ will be required."
    ;; because it doesn't produce an error in a buffer without a mark
    (if (use-region-p) (list (region-beginning) (region-end))
      (list nil nil)))
-  (let* ((word (wiktionary-bro--get-original-word beginning end))
+  (let* ((word (or term (wiktionary-bro--get-original-word beginning end)))
          (url (format
                "https://en.wiktionary.org/w/api.php?action=parse&format=json&page=%s"
                word)))

--- a/wiktionary-bro.el
+++ b/wiktionary-bro.el
@@ -39,7 +39,7 @@
   "Keymap for `wiktionary-bro-mode'.")
 
 (define-derived-mode wiktionary-bro-mode
-  text-mode "Wiktionary"
+  special-mode "Wiktionary"
   "Major mode for browsing Wiktionary entries.")
 
 (defun wiktionary-bro--at-the-beginning-of-word-p (word-point)


### PR DESCRIPTION
this way it can be called programmatically, e.g. from other packages.