### PR TITLE
fails to render 'jump'

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,5 +1,8 @@
 #+TITLE: wiktionary-bro changelog
 
+* [1.1.2] - 2025-12-18
+- Fixed the bug with link handling with various DOM structures
+
 * [1.1.1] - 2025-12-09
 - Buffer naming follows Emacs conventions: ~*wiktionary: word*~
 - External links now open in EWW by default (customizable via ~browse-url-browser-function~)


### PR DESCRIPTION
Fixes #18 

The package was failing with the error `shr-tag-a: Wrong type argument: stringp, nil` when rendering certain Wiktionary pages (e.g., "jump"). This occurred when HTML links had no content or nil content.

The `shr-tag-a` override function made assumptions about the DOM structure that didn't account for: 1. Links with no content: `(a ((href "url")))` 2. Links with empty string content: `(a ((href "url")) "")` 3. Links with nil href attribute

The original code tried to access `(caddr dom)` and `(caddr (caddr dom))` without checking if they were nil or handling the case gracefully.

Solution: Fixed two `shr-tag-a` overrides in the code